### PR TITLE
Highlight the different between the apps

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import styled, { ThemeProvider} from "styled-components";
-import { Box } from 'reas'
 
 const OuterWrapper = styled.div`
   padding: 4em;
@@ -40,7 +39,6 @@ const App = () => (
       <InnerWrapper>
         <Title>Hello World, this is my first styled component!</Title>
       </InnerWrapper>
-      <Box backgroundColor="palevioletred" color="white">Box</Box>
     </div>
     </div>
   </ThemeProvider>


### PR DESCRIPTION
I read trough the https://github.com/styled-components/styled-components/issues/1676 issue, and just to clarify what is changing between the branches I though this PR was a great way of highlighting the problem. 

The relation between that apps and the code is like this:
* `master`: https://sc-next-bug-mizjydjbep.now.sh/ 
* `working`: https://sc-next-bug-jfmvebfqne.now.sh/ 

And as we see from this PR the only diff between them is the import and usage of 'reas'
And reas is only an example, we see the same bug when using a component from  https://github.com/dbmedialab/shiny/.  All other styles is correctly render on the server and the client  correctly matches these.

```
  // This works on server but not client
  ${OuterWrapper} + * & {
    background: palevioletred;
    h1 {
      color: papayawhip;
    }
  }
```

If we change the selector to be 
```
 ${OuterWrapper} + div & {
    background: palevioletred;
    h1 {
      color: papayawhip;
    }
  }
```
the client and server side styles is matching.   